### PR TITLE
Add bedgraph export and optional base range params for CSV/BEDGRAPH exports

### DIFF
--- a/DNA_analyser_IBP/adapters/cpg_adapter.py
+++ b/DNA_analyser_IBP/adapters/cpg_adapter.py
@@ -177,7 +177,7 @@ class CpGAdapter(BaseAdapter, BaseAnalyseAdapter):
     
     @tenacity.retry(wait=Config.TENACITY_CONFIG.WAIT, stop=Config.TENACITY_CONFIG.STOP)
     @login_required
-    def export_csv(self, id: str) -> str:
+    def export_csv(self, id: str, base_start: int = 0, base_end: int = 0) -> str:
         """
         Send GET to /analyse/cpg/{id}/cpg.csv
 
@@ -189,9 +189,12 @@ class CpGAdapter(BaseAdapter, BaseAnalyseAdapter):
         """
         header: dict = {"Accept": "text/plain", "Authorization": self.user.jwt}
 
+        params: dict = {"base_start": base_start, "base_end": base_end}
+
         response: Response = requests.get(
             join_url(self.user.server, Config.ENDPOINT_CONFIG.CPG, id, "cpg.csv"),
             headers=header,
+            params=params,
         )
 
         return validate_text_response(response=response, status_code=200)
@@ -199,7 +202,7 @@ class CpGAdapter(BaseAdapter, BaseAnalyseAdapter):
 
     @tenacity.retry(wait=Config.TENACITY_CONFIG.WAIT, stop=Config.TENACITY_CONFIG.STOP)
     @login_required
-    def export_bedgraph(self, id: str) -> str:
+    def export_bedgraph(self, id: str, base_start: int = 0, base_end: int = 0) -> str:
         """
         Send GET to /analyse/cpg/{id}/cpg.bedgraph
 
@@ -211,9 +214,12 @@ class CpGAdapter(BaseAdapter, BaseAnalyseAdapter):
         """
         header: dict = {"Accept": "text/plain", "Authorization": self.user.jwt}
 
+        params: dict = {"base_start": base_start, "base_end": base_end}
+
         response: Response = requests.get(
             join_url(self.user.server, Config.ENDPOINT_CONFIG.CPG, id, "cpg.bedgraph"),
             headers=header,
+            params=params,
         )
 
         return validate_text_response(response=response, status_code=200)

--- a/DNA_analyser_IBP/adapters/cpg_adapter.py
+++ b/DNA_analyser_IBP/adapters/cpg_adapter.py
@@ -196,6 +196,28 @@ class CpGAdapter(BaseAdapter, BaseAnalyseAdapter):
 
         return validate_text_response(response=response, status_code=200)
     
+
+    @tenacity.retry(wait=Config.TENACITY_CONFIG.WAIT, stop=Config.TENACITY_CONFIG.STOP)
+    @login_required
+    def export_bedgraph(self, id: str) -> str:
+        """
+        Send GET to /analyse/cpg/{id}/cpg.bedgraph
+
+        Args:
+            id (str): cpg analyse id
+
+        Returns:
+            str: bedgraph file in string
+        """
+        header: dict = {"Accept": "text/plain", "Authorization": self.user.jwt}
+
+        response: Response = requests.get(
+            join_url(self.user.server, Config.ENDPOINT_CONFIG.CPG, id, "cpg.bedgraph"),
+            headers=header,
+        )
+
+        return validate_text_response(response=response, status_code=200)
+
     @login_required
     def load_result(self, id: str) -> pd.DataFrame:
         """

--- a/DNA_analyser_IBP/adapters/g4hunter_adapter.py
+++ b/DNA_analyser_IBP/adapters/g4hunter_adapter.py
@@ -194,7 +194,13 @@ class G4HunterAdapter(BaseAdapter, BaseAnalyseAdapter):
 
     @tenacity.retry(wait=Config.TENACITY_CONFIG.WAIT, stop=Config.TENACITY_CONFIG.STOP)
     @login_required
-    def export_csv(self, id: str, aggregate: bool = True) -> str:
+    def export_csv(
+        self,
+        id: str,
+        aggregate: bool = True,
+        base_start: int = 0,
+        base_end: int = 0,
+    ) -> str:
         """
         Send GET to /analyse/g4hunter/{id}/quadruplex.csv
 
@@ -206,7 +212,11 @@ class G4HunterAdapter(BaseAdapter, BaseAnalyseAdapter):
             str: csv file in string
         """
         header: dict = {"Accept": "text/plain", "Authorization": self.user.jwt}
-        params: dict = {"aggregate": "true" if aggregate else "false"}
+        params: dict = {
+            "aggregate": "true" if aggregate else "false",
+            "base_start": base_start,
+            "base_end": base_end,
+        }
 
         response: Response = requests.get(
             join_url(
@@ -220,7 +230,13 @@ class G4HunterAdapter(BaseAdapter, BaseAnalyseAdapter):
 
     @tenacity.retry(wait=Config.TENACITY_CONFIG.WAIT, stop=Config.TENACITY_CONFIG.STOP)
     @login_required
-    def export_bedgraph(self, id: str, aggregate: bool = True) -> str:
+    def export_bedgraph(
+        self,
+        id: str,
+        aggregate: bool = True,
+        base_start: int = 0,
+        base_end: int = 0,
+    ) -> str:
         """
         Send GET to /analyse/g4hunter/{id}/quadruplex.bedgraph
 
@@ -232,7 +248,11 @@ class G4HunterAdapter(BaseAdapter, BaseAnalyseAdapter):
             str: bedgraph file in string
         """
         header: dict = {"Accept": "text/plain", "Authorization": self.user.jwt}
-        params: dict = {"aggregate": "true" if aggregate else "false"}
+        params: dict = {
+            "aggregate": "true" if aggregate else "false",
+            "base_start": base_start,
+            "base_end": base_end,
+        }
 
         response: Response = requests.get(
             join_url(

--- a/DNA_analyser_IBP/adapters/g4hunter_adapter.py
+++ b/DNA_analyser_IBP/adapters/g4hunter_adapter.py
@@ -218,6 +218,35 @@ class G4HunterAdapter(BaseAdapter, BaseAnalyseAdapter):
 
         return validate_text_response(response=response, status_code=200)
 
+    @tenacity.retry(wait=Config.TENACITY_CONFIG.WAIT, stop=Config.TENACITY_CONFIG.STOP)
+    @login_required
+    def export_bedgraph(self, id: str, aggregate: bool = True) -> str:
+        """
+        Send GET to /analyse/g4hunter/{id}/quadruplex.bedgraph
+
+        Args:
+            id (str): g4hunter analyse id
+            aggregate (bool): True if aggregate results else False
+
+        Returns:
+            str: bedgraph file in string
+        """
+        header: dict = {"Accept": "text/plain", "Authorization": self.user.jwt}
+        params: dict = {"aggregate": "true" if aggregate else "false"}
+
+        response: Response = requests.get(
+            join_url(
+                self.user.server,
+                Config.ENDPOINT_CONFIG.G4HUNTER,
+                id,
+                "quadruplex.bedgraph",
+            ),
+            headers=header,
+            params=params,
+        )
+
+        return validate_text_response(response=response, status_code=200)
+
     @login_required
     def load_heatmap(self, id: str, segments: int) -> pd.DataFrame:
         """

--- a/DNA_analyser_IBP/adapters/rloopr_adapter.py
+++ b/DNA_analyser_IBP/adapters/rloopr_adapter.py
@@ -172,6 +172,30 @@ class RLooprAdapter(BaseAdapter, BaseAnalyseAdapter):
 
         return validate_text_response(response=response, status_code=200)
 
+
+    @tenacity.retry(wait=Config.TENACITY_CONFIG.WAIT, stop=Config.TENACITY_CONFIG.STOP)
+    @login_required
+    def export_bedgraph(self, id: str) -> str:
+        """
+        Send GET to /analyse/rloopr/{id}/rloopr.bedgraph
+
+        Args:
+            id (str): rloopr analyse id
+
+        Returns:
+            str: bedgraph file in string
+        """
+        header: dict = {"Accept": "text/plain", "Authorization": self.user.jwt}
+
+        response: Response = requests.get(
+            join_url(
+                self.user.server, Config.ENDPOINT_CONFIG.RLOOPR, id, "rloopr.bedgraph"
+            ),
+            headers=header,
+        )
+
+        return validate_text_response(response=response, status_code=200)
+
     @login_required
     def load_result(self, id: str) -> pd.DataFrame:
         """

--- a/DNA_analyser_IBP/adapters/rloopr_adapter.py
+++ b/DNA_analyser_IBP/adapters/rloopr_adapter.py
@@ -153,7 +153,7 @@ class RLooprAdapter(BaseAdapter, BaseAnalyseAdapter):
 
     @tenacity.retry(wait=Config.TENACITY_CONFIG.WAIT, stop=Config.TENACITY_CONFIG.STOP)
     @login_required
-    def export_csv(self, id: str) -> str:
+    def export_csv(self, id: str, base_start: int = 0, base_end: int = 0) -> str:
         """
         Send GET to /analyse/rloopr/{id}/rloopr.csv
 
@@ -165,9 +165,12 @@ class RLooprAdapter(BaseAdapter, BaseAnalyseAdapter):
         """
         header: dict = {"Accept": "text/plain", "Authorization": self.user.jwt}
 
+        params: dict = {"base_start": base_start, "base_end": base_end}
+
         response: Response = requests.get(
             join_url(self.user.server, Config.ENDPOINT_CONFIG.RLOOPR, id, "rloopr.csv"),
             headers=header,
+            params=params,
         )
 
         return validate_text_response(response=response, status_code=200)
@@ -175,7 +178,7 @@ class RLooprAdapter(BaseAdapter, BaseAnalyseAdapter):
 
     @tenacity.retry(wait=Config.TENACITY_CONFIG.WAIT, stop=Config.TENACITY_CONFIG.STOP)
     @login_required
-    def export_bedgraph(self, id: str) -> str:
+    def export_bedgraph(self, id: str, base_start: int = 0, base_end: int = 0) -> str:
         """
         Send GET to /analyse/rloopr/{id}/rloopr.bedgraph
 
@@ -187,11 +190,14 @@ class RLooprAdapter(BaseAdapter, BaseAnalyseAdapter):
         """
         header: dict = {"Accept": "text/plain", "Authorization": self.user.jwt}
 
+        params: dict = {"base_start": base_start, "base_end": base_end}
+
         response: Response = requests.get(
             join_url(
                 self.user.server, Config.ENDPOINT_CONFIG.RLOOPR, id, "rloopr.bedgraph"
             ),
             headers=header,
+            params=params,
         )
 
         return validate_text_response(response=response, status_code=200)

--- a/DNA_analyser_IBP/adapters/zdna_adapter.py
+++ b/DNA_analyser_IBP/adapters/zdna_adapter.py
@@ -175,6 +175,28 @@ class ZDnaAdapter(BaseAdapter, BaseAnalyseAdapter):
             return True
         return False
 
+
+    @tenacity.retry(wait=Config.TENACITY_CONFIG.WAIT, stop=Config.TENACITY_CONFIG.STOP)
+    @login_required
+    def export_bedgraph(self, id: str) -> str:
+        """
+        Send GET to /analyse/zdna/{id}/zdna.bedgraph
+
+        Args:
+            id (str): Z-DNA analyse id
+
+        Returns:
+            str: bedgraph file in string
+        """
+        header: dict = {"Accept": "text/plain", "Authorization": self.user.jwt}
+
+        response: Response = requests.get(
+            join_url(self.user.server, Config.ENDPOINT_CONFIG.ZDNA, id, "zdna.bedgraph"),
+            headers=header,
+        )
+
+        return validate_text_response(response=response, status_code=200)
+
     @login_required
     def load_result(self, id: str) -> pd.DataFrame:
         """

--- a/DNA_analyser_IBP/adapters/zdna_adapter.py
+++ b/DNA_analyser_IBP/adapters/zdna_adapter.py
@@ -178,7 +178,7 @@ class ZDnaAdapter(BaseAdapter, BaseAnalyseAdapter):
 
     @tenacity.retry(wait=Config.TENACITY_CONFIG.WAIT, stop=Config.TENACITY_CONFIG.STOP)
     @login_required
-    def export_bedgraph(self, id: str) -> str:
+    def export_bedgraph(self, id: str, base_start: int = 0, base_end: int = 0) -> str:
         """
         Send GET to /analyse/zdna/{id}/zdna.bedgraph
 
@@ -190,9 +190,12 @@ class ZDnaAdapter(BaseAdapter, BaseAnalyseAdapter):
         """
         header: dict = {"Accept": "text/plain", "Authorization": self.user.jwt}
 
+        params: dict = {"base_start": base_start, "base_end": base_end}
+
         response: Response = requests.get(
             join_url(self.user.server, Config.ENDPOINT_CONFIG.ZDNA, id, "zdna.bedgraph"),
             headers=header,
+            params=params,
         )
 
         return validate_text_response(response=response, status_code=200)
@@ -228,7 +231,7 @@ class ZDnaAdapter(BaseAdapter, BaseAnalyseAdapter):
 
     @tenacity.retry(wait=Config.TENACITY_CONFIG.WAIT, stop=Config.TENACITY_CONFIG.STOP)
     @login_required
-    def export_csv(self, id: str) -> str:
+    def export_csv(self, id: str, base_start: int = 0, base_end: int = 0) -> str:
         """
         Send GET to /analyse/zdna/{id}/zdna.csv
 
@@ -240,9 +243,12 @@ class ZDnaAdapter(BaseAdapter, BaseAnalyseAdapter):
         """
         header: dict = {"Accept": "text/plain", "Authorization": self.user.jwt}
 
+        params: dict = {"base_start": base_start, "base_end": base_end}
+
         response: Response = requests.get(
             join_url(self.user.server, Config.ENDPOINT_CONFIG.ZDNA, id, "zdna.csv"),
             headers=header,
+            params=params,
         )
 
         return validate_text_response(response=response, status_code=200)

--- a/DNA_analyser_IBP/interfaces/cpg_interface.py
+++ b/DNA_analyser_IBP/interfaces/cpg_interface.py
@@ -153,6 +153,8 @@ class CpG(AnalyseInterface):
         *,
         analyse: Union[pd.DataFrame, pd.Series],
         path: str,
+        base_start: int = 0,
+        base_end: int = 0,
     ) -> None:
         """
         Export CpX analyses result into csv files
@@ -167,7 +169,9 @@ class CpG(AnalyseInterface):
             file_path: str = os.path.join(path, f"{name}_result.csv")
 
             with open(file_path, "w") as new_file:
-                data: str = self.__ports.cpg.export_csv(id=id)
+                data: str = self.__ports.cpg.export_csv(
+                    id=id, base_start=base_start, base_end=base_end
+                )
                 new_file.write(data)
             Logger.info(f"file created -> {file_path}")
 
@@ -184,6 +188,8 @@ class CpG(AnalyseInterface):
         *,
         analyse: Union[pd.DataFrame, pd.Series],
         path: str,
+        base_start: int = 0,
+        base_end: int = 0,
     ) -> None:
         """
         Export CpX analyses result into bedgraph files
@@ -198,7 +204,9 @@ class CpG(AnalyseInterface):
             file_path: str = os.path.join(path, f"{name}_result.bed")
 
             with open(file_path, "w") as new_file:
-                data: str = self.__ports.cpg.export_bedgraph(id=id)
+                data: str = self.__ports.cpg.export_bedgraph(
+                    id=id, base_start=base_start, base_end=base_end
+                )
                 new_file.write(data)
             Logger.info(f"file created -> {file_path}")
 

--- a/DNA_analyser_IBP/interfaces/cpg_interface.py
+++ b/DNA_analyser_IBP/interfaces/cpg_interface.py
@@ -177,6 +177,37 @@ class CpG(AnalyseInterface):
         else:
             _export_csv(id=analyse["id"], name=analyse["title"])
 
+
+    @exception_handler
+    def export_bedgraph(
+        self,
+        *,
+        analyse: Union[pd.DataFrame, pd.Series],
+        path: str,
+    ) -> None:
+        """
+        Export CpX analyses result into bedgraph files
+
+        Args:
+            analyse (Union[pd.DataFrame, pd.Series]): cpg analyse DataFrame|Series
+            path (str): absolute system path to output folder
+        """
+
+        def _export_bedgraph(id: str, name: str) -> None:
+            name: str = normalize_name(name=name)
+            file_path: str = os.path.join(path, f"{name}_result.bed")
+
+            with open(file_path, "w") as new_file:
+                data: str = self.__ports.cpg.export_bedgraph(id=id)
+                new_file.write(data)
+            Logger.info(f"file created -> {file_path}")
+
+        if isinstance(analyse, pd.DataFrame):
+            for _, row in analyse.iterrows():
+                _export_bedgraph(id=row["id"], name=row["title"])
+        else:
+            _export_bedgraph(id=analyse["id"], name=analyse["title"])
+
     @exception_handler
     def load_results(self, *, analyse: Union[pd.Series, pd.DataFrame]) -> pd.DataFrame:
         """

--- a/DNA_analyser_IBP/interfaces/g4hunter_interface.py
+++ b/DNA_analyser_IBP/interfaces/g4hunter_interface.py
@@ -255,6 +255,8 @@ class G4Hunter(AnalyseInterface):
         analyse: Union[pd.DataFrame, pd.Series],
         path: str,
         aggregate: bool = True,
+        base_start: int = 0,
+        base_end: int = 0,
     ) -> None:
         """
         Export G4Hunter analyses result into csv files
@@ -270,7 +272,12 @@ class G4Hunter(AnalyseInterface):
             file_path: str = os.path.join(path, f"{name}_{id}_result.csv")
 
             with open(file_path, "w") as new_file:
-                data: str = self.__ports.g4hunter.export_csv(id=id, aggregate=aggregate)
+                data: str = self.__ports.g4hunter.export_csv(
+                    id=id,
+                    aggregate=aggregate,
+                    base_start=base_start,
+                    base_end=base_end,
+                )
                 new_file.write(data)
             Logger.info(f"file created -> {file_path}")
 
@@ -288,6 +295,8 @@ class G4Hunter(AnalyseInterface):
         analyse: Union[pd.DataFrame, pd.Series],
         path: str,
         aggregate: bool = True,
+        base_start: int = 0,
+        base_end: int = 0,
     ) -> None:
         """
         Export G4Hunter analyses result into bedgraph files
@@ -304,7 +313,10 @@ class G4Hunter(AnalyseInterface):
 
             with open(file_path, "w") as new_file:
                 data: str = self.__ports.g4hunter.export_bedgraph(
-                    id=id, aggregate=aggregate
+                    id=id,
+                    aggregate=aggregate,
+                    base_start=base_start,
+                    base_end=base_end,
                 )
                 new_file.write(data)
             Logger.info(f"file created -> {file_path}")

--- a/DNA_analyser_IBP/interfaces/g4hunter_interface.py
+++ b/DNA_analyser_IBP/interfaces/g4hunter_interface.py
@@ -280,6 +280,41 @@ class G4Hunter(AnalyseInterface):
         else:
             _export_csv(id=analyse["id"], name=analyse["title"])
 
+
+    @exception_handler
+    def export_bedgraph(
+        self,
+        *,
+        analyse: Union[pd.DataFrame, pd.Series],
+        path: str,
+        aggregate: bool = True,
+    ) -> None:
+        """
+        Export G4Hunter analyses result into bedgraph files
+
+        Args:
+            analyse (Union[pd.DataFrame, pd.Series]): g4hunter analyse DataFrame|Series
+            path (str): absolute system path to output folder
+            aggregate (bool): True = aggregation, False = no aggregation
+        """
+
+        def _export_bedgraph(id: str, name: str) -> None:
+            name: str = normalize_name(name=name)
+            file_path: str = os.path.join(path, f"{name}_{id}_result.bed")
+
+            with open(file_path, "w") as new_file:
+                data: str = self.__ports.g4hunter.export_bedgraph(
+                    id=id, aggregate=aggregate
+                )
+                new_file.write(data)
+            Logger.info(f"file created -> {file_path}")
+
+        if isinstance(analyse, pd.DataFrame):
+            for _, row in analyse.iterrows():
+                _export_bedgraph(id=row["id"], name=row["title"])
+        else:
+            _export_bedgraph(id=analyse["id"], name=analyse["title"])
+
     @exception_handler
     def delete(self, *, analyse: Union[pd.DataFrame, pd.Series]) -> None:
         """

--- a/DNA_analyser_IBP/interfaces/rloopr_interface.py
+++ b/DNA_analyser_IBP/interfaces/rloopr_interface.py
@@ -189,6 +189,37 @@ class Rloopr(AnalyseInterface):
         else:
             _export_csv(id=analyse["id"], name=analyse["title"])
 
+
+    @exception_handler
+    def export_bedgraph(
+        self,
+        *,
+        analyse: Union[pd.DataFrame, pd.Series],
+        path: str,
+    ) -> None:
+        """
+        Export RLoopr analyses result into bedgraph files
+
+        Args:
+            analyse (Union[pd.DataFrame, pd.Series]): rloopr analyse DataFrame|Series
+            path (str): absolute system path to output folder
+        """
+
+        def _export_bedgraph(id: str, name: str) -> None:
+            name: str = normalize_name(name=name)
+            file_path: str = os.path.join(path, f"{name}_result.bed")
+
+            with open(file_path, "w") as new_file:
+                data: str = self.__ports.rloopr.export_bedgraph(id=id)
+                new_file.write(data)
+            Logger.info(f"file created -> {file_path}")
+
+        if isinstance(analyse, pd.DataFrame):
+            for _, row in analyse.iterrows():
+                _export_bedgraph(id=row["id"], name=row["title"])
+        else:
+            _export_bedgraph(id=analyse["id"], name=analyse["title"])
+
     @exception_handler
     def load_results(self, *, analyse: Union[pd.Series, pd.DataFrame]) -> pd.DataFrame:
         """

--- a/DNA_analyser_IBP/interfaces/rloopr_interface.py
+++ b/DNA_analyser_IBP/interfaces/rloopr_interface.py
@@ -165,6 +165,8 @@ class Rloopr(AnalyseInterface):
         *,
         analyse: Union[pd.DataFrame, pd.Series],
         path: str,
+        base_start: int = 0,
+        base_end: int = 0,
     ) -> None:
         """
         Export RLoopr analyses result into csv files
@@ -179,7 +181,9 @@ class Rloopr(AnalyseInterface):
             file_path: str = os.path.join(path, f"{name}_result.csv")
 
             with open(file_path, "w") as new_file:
-                data: str = self.__ports.g4hunter.export_csv(id=id)
+                data: str = self.__ports.rloopr.export_csv(
+                    id=id, base_start=base_start, base_end=base_end
+                )
                 new_file.write(data)
             Logger.info(f"file created -> {file_path}")
 
@@ -196,6 +200,8 @@ class Rloopr(AnalyseInterface):
         *,
         analyse: Union[pd.DataFrame, pd.Series],
         path: str,
+        base_start: int = 0,
+        base_end: int = 0,
     ) -> None:
         """
         Export RLoopr analyses result into bedgraph files
@@ -210,7 +216,9 @@ class Rloopr(AnalyseInterface):
             file_path: str = os.path.join(path, f"{name}_result.bed")
 
             with open(file_path, "w") as new_file:
-                data: str = self.__ports.rloopr.export_bedgraph(id=id)
+                data: str = self.__ports.rloopr.export_bedgraph(
+                    id=id, base_start=base_start, base_end=base_end
+                )
                 new_file.write(data)
             Logger.info(f"file created -> {file_path}")
 

--- a/DNA_analyser_IBP/interfaces/zdna_interface.py
+++ b/DNA_analyser_IBP/interfaces/zdna_interface.py
@@ -285,6 +285,8 @@ class ZDna(AnalyseInterface):
         *,
         analyse: Union[pd.DataFrame, pd.Series],
         path: str,
+        base_start: int = 0,
+        base_end: int = 0,
     ) -> None:
         """
         Export z-dna analyses result into csv files
@@ -299,7 +301,9 @@ class ZDna(AnalyseInterface):
             file_path: str = os.path.join(path, f"{name}_{id}_result.csv")
 
             with open(file_path, "w") as new_file:
-                data: str = self.__ports.zdna.export_csv(id=id)
+                data: str = self.__ports.zdna.export_csv(
+                    id=id, base_start=base_start, base_end=base_end
+                )
                 new_file.write(data)
             Logger.info(f"file created -> {file_path}")
 
@@ -316,6 +320,8 @@ class ZDna(AnalyseInterface):
         *,
         analyse: Union[pd.DataFrame, pd.Series],
         path: str,
+        base_start: int = 0,
+        base_end: int = 0,
     ) -> None:
         """
         Export z-dna analyses result into bedgraph files
@@ -330,7 +336,9 @@ class ZDna(AnalyseInterface):
             file_path: str = os.path.join(path, f"{name}_{id}_result.bed")
 
             with open(file_path, "w") as new_file:
-                data: str = self.__ports.zdna.export_bedgraph(id=id)
+                data: str = self.__ports.zdna.export_bedgraph(
+                    id=id, base_start=base_start, base_end=base_end
+                )
                 new_file.write(data)
             Logger.info(f"file created -> {file_path}")
 

--- a/DNA_analyser_IBP/interfaces/zdna_interface.py
+++ b/DNA_analyser_IBP/interfaces/zdna_interface.py
@@ -309,6 +309,37 @@ class ZDna(AnalyseInterface):
         else:
             _export_csv(id=analyse["id"], name=analyse["title"])
 
+
+    @exception_handler
+    def export_bedgraph(
+        self,
+        *,
+        analyse: Union[pd.DataFrame, pd.Series],
+        path: str,
+    ) -> None:
+        """
+        Export z-dna analyses result into bedgraph files
+
+        Args:
+            analyse (Union[pd.DataFrame, pd.Series]): z-dna analyse DataFrame|Series
+            path (str): absolute system path to output folder
+        """
+
+        def _export_bedgraph(id: str, name: str) -> None:
+            name: str = normalize_name(name=name)
+            file_path: str = os.path.join(path, f"{name}_{id}_result.bed")
+
+            with open(file_path, "w") as new_file:
+                data: str = self.__ports.zdna.export_bedgraph(id=id)
+                new_file.write(data)
+            Logger.info(f"file created -> {file_path}")
+
+        if isinstance(analyse, pd.DataFrame):
+            for _, row in analyse.iterrows():
+                _export_bedgraph(id=row["id"], name=row["title"])
+        else:
+            _export_bedgraph(id=analyse["id"], name=analyse["title"])
+
     @exception_handler
     def delete(self, *, analyse: Union[pd.DataFrame, pd.Series]) -> None:
         """

--- a/DNA_analyser_IBP/ports/cpg_port.py
+++ b/DNA_analyser_IBP/ports/cpg_port.py
@@ -47,12 +47,12 @@ class CpGPort(Port):
     def delete(self, *, id: str) -> bool:
         return self.adapter.cpg.delete(id=id)
     
-    def export_csv(self, *, id: str) -> str:
-        return self.adapter.cpg.export_csv(id=id)
+    def export_csv(self, *, id: str, base_start: int = 0, base_end: int = 0) -> str:
+        return self.adapter.cpg.export_csv(id=id, base_start=base_start, base_end=base_end)
     
 
-    def export_bedgraph(self, *, id: str) -> str:
-        return self.adapter.cpg.export_bedgraph(id=id)
+    def export_bedgraph(self, *, id: str, base_start: int = 0, base_end: int = 0) -> str:
+        return self.adapter.cpg.export_bedgraph(id=id, base_start=base_start, base_end=base_end)
 
     def load_result(self, *, id: str) -> "DataFrame":
         return self.adapter.cpg.load_result(id=id)

--- a/DNA_analyser_IBP/ports/cpg_port.py
+++ b/DNA_analyser_IBP/ports/cpg_port.py
@@ -50,5 +50,9 @@ class CpGPort(Port):
     def export_csv(self, *, id: str) -> str:
         return self.adapter.cpg.export_csv(id=id)
     
+
+    def export_bedgraph(self, *, id: str) -> str:
+        return self.adapter.cpg.export_bedgraph(id=id)
+
     def load_result(self, *, id: str) -> "DataFrame":
         return self.adapter.cpg.load_result(id=id)

--- a/DNA_analyser_IBP/ports/g4hunter_port.py
+++ b/DNA_analyser_IBP/ports/g4hunter_port.py
@@ -44,12 +44,36 @@ class G4HunterPort(Port):
     def load_result(self, *, id: str) -> "DataFrame":
         return self.adapter.g4hunter.load_result(id=id)
 
-    def export_csv(self, *, id: str, aggregate: bool = True) -> str:
-        return self.adapter.g4hunter.export_csv(id=id, aggregate=aggregate)
+    def export_csv(
+        self,
+        *,
+        id: str,
+        aggregate: bool = True,
+        base_start: int = 0,
+        base_end: int = 0,
+    ) -> str:
+        return self.adapter.g4hunter.export_csv(
+            id=id,
+            aggregate=aggregate,
+            base_start=base_start,
+            base_end=base_end,
+        )
 
 
-    def export_bedgraph(self, *, id: str, aggregate: bool = True) -> str:
-        return self.adapter.g4hunter.export_bedgraph(id=id, aggregate=aggregate)
+    def export_bedgraph(
+        self,
+        *,
+        id: str,
+        aggregate: bool = True,
+        base_start: int = 0,
+        base_end: int = 0,
+    ) -> str:
+        return self.adapter.g4hunter.export_bedgraph(
+            id=id,
+            aggregate=aggregate,
+            base_start=base_start,
+            base_end=base_end,
+        )
 
     def load_heatmap(self, *, id: str, segments: int) -> "DataFrame":
         return self.adapter.g4hunter.load_heatmap(id=id, segments=segments)

--- a/DNA_analyser_IBP/ports/g4hunter_port.py
+++ b/DNA_analyser_IBP/ports/g4hunter_port.py
@@ -47,5 +47,9 @@ class G4HunterPort(Port):
     def export_csv(self, *, id: str, aggregate: bool = True) -> str:
         return self.adapter.g4hunter.export_csv(id=id, aggregate=aggregate)
 
+
+    def export_bedgraph(self, *, id: str, aggregate: bool = True) -> str:
+        return self.adapter.g4hunter.export_bedgraph(id=id, aggregate=aggregate)
+
     def load_heatmap(self, *, id: str, segments: int) -> "DataFrame":
         return self.adapter.g4hunter.load_heatmap(id=id, segments=segments)

--- a/DNA_analyser_IBP/ports/rloopr_port.py
+++ b/DNA_analyser_IBP/ports/rloopr_port.py
@@ -39,5 +39,9 @@ class RlooprPort(Port):
     def export_csv(self, *, id: str) -> str:
         return self.adapter.rloopr.export_csv(id=id)
 
+
+    def export_bedgraph(self, *, id: str) -> str:
+        return self.adapter.rloopr.export_bedgraph(id=id)
+
     def load_result(self, *, id: str) -> "DataFrame":
         return self.adapter.rloopr.load_result(id=id)

--- a/DNA_analyser_IBP/ports/rloopr_port.py
+++ b/DNA_analyser_IBP/ports/rloopr_port.py
@@ -36,12 +36,12 @@ class RlooprPort(Port):
     def delete(self, *, id: str) -> bool:
         return self.adapter.rloopr.delete(id=id)
 
-    def export_csv(self, *, id: str) -> str:
-        return self.adapter.rloopr.export_csv(id=id)
+    def export_csv(self, *, id: str, base_start: int = 0, base_end: int = 0) -> str:
+        return self.adapter.rloopr.export_csv(id=id, base_start=base_start, base_end=base_end)
 
 
-    def export_bedgraph(self, *, id: str) -> str:
-        return self.adapter.rloopr.export_bedgraph(id=id)
+    def export_bedgraph(self, *, id: str, base_start: int = 0, base_end: int = 0) -> str:
+        return self.adapter.rloopr.export_bedgraph(id=id, base_start=base_start, base_end=base_end)
 
     def load_result(self, *, id: str) -> "DataFrame":
         return self.adapter.rloopr.load_result(id=id)

--- a/DNA_analyser_IBP/ports/zdna_port.py
+++ b/DNA_analyser_IBP/ports/zdna_port.py
@@ -60,5 +60,9 @@ class ZDnaPort(Port):
     def export_csv(self, *, id: str) -> str:
         return self.adapter.zdna.export_csv(id=id)
 
+
+    def export_bedgraph(self, *, id: str) -> str:
+        return self.adapter.zdna.export_bedgraph(id=id)
+
     def load_heatmap(self, *, id: str, segments: int) -> "DataFrame":
         return self.adapter.zdna.load_heatmap(id=id, segments=segments)

--- a/DNA_analyser_IBP/ports/zdna_port.py
+++ b/DNA_analyser_IBP/ports/zdna_port.py
@@ -57,12 +57,12 @@ class ZDnaPort(Port):
     def load_result(self, *, id: str) -> "DataFrame":
         return self.adapter.zdna.load_result(id=id)
 
-    def export_csv(self, *, id: str) -> str:
-        return self.adapter.zdna.export_csv(id=id)
+    def export_csv(self, *, id: str, base_start: int = 0, base_end: int = 0) -> str:
+        return self.adapter.zdna.export_csv(id=id, base_start=base_start, base_end=base_end)
 
 
-    def export_bedgraph(self, *, id: str) -> str:
-        return self.adapter.zdna.export_bedgraph(id=id)
+    def export_bedgraph(self, *, id: str, base_start: int = 0, base_end: int = 0) -> str:
+        return self.adapter.zdna.export_bedgraph(id=id, base_start=base_start, base_end=base_end)
 
     def load_heatmap(self, *, id: str, segments: int) -> "DataFrame":
         return self.adapter.zdna.load_heatmap(id=id, segments=segments)

--- a/tests/test_adapters/bedgraph_export_adapter_test.py
+++ b/tests/test_adapters/bedgraph_export_adapter_test.py
@@ -1,0 +1,107 @@
+from types import SimpleNamespace
+
+import DNA_analyser_IBP.adapters.cpg_adapter as cpg_adapter_module
+import DNA_analyser_IBP.adapters.g4hunter_adapter as g4hunter_adapter_module
+import DNA_analyser_IBP.adapters.rloopr_adapter as rloopr_adapter_module
+import DNA_analyser_IBP.adapters.zdna_adapter as zdna_adapter_module
+from DNA_analyser_IBP.adapters.cpg_adapter import CpGAdapter
+from DNA_analyser_IBP.adapters.g4hunter_adapter import G4HunterAdapter
+from DNA_analyser_IBP.adapters.rloopr_adapter import RLooprAdapter
+from DNA_analyser_IBP.adapters.zdna_adapter import ZDnaAdapter
+from DNA_analyser_IBP.models import User
+
+
+def _user() -> User:
+    user = User(email="test@test.cz", password="password", server="http://localhost")
+    user.jwt = "jwt"
+    return user
+
+
+def test_g4hunter_export_bedgraph(monkeypatch):
+    captured = {}
+
+    def fake_get(url, headers, params):
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["params"] = params
+        return SimpleNamespace(status_code=200, text="content")
+
+    monkeypatch.setattr(g4hunter_adapter_module.requests, "get", fake_get)
+    monkeypatch.setattr(
+        g4hunter_adapter_module,
+        "validate_text_response",
+        lambda response, status_code: response.text,
+    )
+
+    adapter = G4HunterAdapter(user=_user())
+    content = adapter.export_bedgraph(id="analyse-id", aggregate=False)
+
+    assert content == "content"
+    assert captured["url"].endswith("/analyse/g4hunter/analyse-id/quadruplex.bedgraph")
+    assert captured["params"] == {"aggregate": "false"}
+
+
+def test_cpg_export_bedgraph(monkeypatch):
+    captured = {}
+
+    def fake_get(url, headers):
+        captured["url"] = url
+        captured["headers"] = headers
+        return SimpleNamespace(status_code=200, text="content")
+
+    monkeypatch.setattr(cpg_adapter_module.requests, "get", fake_get)
+    monkeypatch.setattr(
+        cpg_adapter_module,
+        "validate_text_response",
+        lambda response, status_code: response.text,
+    )
+
+    adapter = CpGAdapter(user=_user())
+    content = adapter.export_bedgraph(id="analyse-id")
+
+    assert content == "content"
+    assert captured["url"].endswith("/analyse/cpg/analyse-id/cpg.bedgraph")
+
+
+def test_rloopr_export_bedgraph(monkeypatch):
+    captured = {}
+
+    def fake_get(url, headers):
+        captured["url"] = url
+        captured["headers"] = headers
+        return SimpleNamespace(status_code=200, text="content")
+
+    monkeypatch.setattr(rloopr_adapter_module.requests, "get", fake_get)
+    monkeypatch.setattr(
+        rloopr_adapter_module,
+        "validate_text_response",
+        lambda response, status_code: response.text,
+    )
+
+    adapter = RLooprAdapter(user=_user())
+    content = adapter.export_bedgraph(id="analyse-id")
+
+    assert content == "content"
+    assert captured["url"].endswith("/analyse/rloopr/analyse-id/rloopr.bedgraph")
+
+
+def test_zdna_export_bedgraph(monkeypatch):
+    captured = {}
+
+    def fake_get(url, headers):
+        captured["url"] = url
+        captured["headers"] = headers
+        return SimpleNamespace(status_code=200, text="content")
+
+    monkeypatch.setattr(zdna_adapter_module.requests, "get", fake_get)
+    monkeypatch.setattr(
+        zdna_adapter_module,
+        "validate_text_response",
+        lambda response, status_code: response.text,
+    )
+
+    adapter = ZDnaAdapter(user=_user())
+    content = adapter.export_bedgraph(id="analyse-id")
+
+    assert content == "content"
+    assert captured["url"].endswith("/analyse/zdna/analyse-id/zdna.bedgraph")

--- a/tests/test_adapters/bedgraph_export_adapter_test.py
+++ b/tests/test_adapters/bedgraph_export_adapter_test.py
@@ -17,13 +17,11 @@ def _user() -> User:
     return user
 
 
-def test_g4hunter_export_bedgraph(monkeypatch):
-    captured = {}
+def test_g4hunter_export_csv_and_bedgraph(monkeypatch):
+    calls = []
 
     def fake_get(url, headers, params):
-        captured["url"] = url
-        captured["headers"] = headers
-        captured["params"] = params
+        calls.append({"url": url, "headers": headers, "params": params})
         return SimpleNamespace(status_code=200, text="content")
 
     monkeypatch.setattr(g4hunter_adapter_module.requests, "get", fake_get)
@@ -34,19 +32,36 @@ def test_g4hunter_export_bedgraph(monkeypatch):
     )
 
     adapter = G4HunterAdapter(user=_user())
-    content = adapter.export_bedgraph(id="analyse-id", aggregate=False)
+    csv_content = adapter.export_csv(
+        id="analyse-id", aggregate=False, base_start=12, base_end=44
+    )
+    bed_content = adapter.export_bedgraph(
+        id="analyse-id", aggregate=False, base_start=12, base_end=44
+    )
 
-    assert content == "content"
-    assert captured["url"].endswith("/analyse/g4hunter/analyse-id/quadruplex.bedgraph")
-    assert captured["params"] == {"aggregate": "false"}
+    assert csv_content == "content"
+    assert bed_content == "content"
+    assert calls[0]["url"].endswith("/analyse/g4hunter/analyse-id/quadruplex.csv")
+    assert calls[1]["url"].endswith(
+        "/analyse/g4hunter/analyse-id/quadruplex.bedgraph"
+    )
+    assert calls[0]["params"] == {
+        "aggregate": "false",
+        "base_start": 12,
+        "base_end": 44,
+    }
+    assert calls[1]["params"] == {
+        "aggregate": "false",
+        "base_start": 12,
+        "base_end": 44,
+    }
 
 
-def test_cpg_export_bedgraph(monkeypatch):
-    captured = {}
+def test_cpg_export_csv_and_bedgraph(monkeypatch):
+    calls = []
 
-    def fake_get(url, headers):
-        captured["url"] = url
-        captured["headers"] = headers
+    def fake_get(url, headers, params):
+        calls.append({"url": url, "headers": headers, "params": params})
         return SimpleNamespace(status_code=200, text="content")
 
     monkeypatch.setattr(cpg_adapter_module.requests, "get", fake_get)
@@ -57,18 +72,22 @@ def test_cpg_export_bedgraph(monkeypatch):
     )
 
     adapter = CpGAdapter(user=_user())
-    content = adapter.export_bedgraph(id="analyse-id")
+    csv_content = adapter.export_csv(id="analyse-id", base_start=1, base_end=2)
+    bed_content = adapter.export_bedgraph(id="analyse-id", base_start=1, base_end=2)
 
-    assert content == "content"
-    assert captured["url"].endswith("/analyse/cpg/analyse-id/cpg.bedgraph")
+    assert csv_content == "content"
+    assert bed_content == "content"
+    assert calls[0]["url"].endswith("/analyse/cpg/analyse-id/cpg.csv")
+    assert calls[1]["url"].endswith("/analyse/cpg/analyse-id/cpg.bedgraph")
+    assert calls[0]["params"] == {"base_start": 1, "base_end": 2}
+    assert calls[1]["params"] == {"base_start": 1, "base_end": 2}
 
 
-def test_rloopr_export_bedgraph(monkeypatch):
-    captured = {}
+def test_rloopr_export_csv_and_bedgraph(monkeypatch):
+    calls = []
 
-    def fake_get(url, headers):
-        captured["url"] = url
-        captured["headers"] = headers
+    def fake_get(url, headers, params):
+        calls.append({"url": url, "headers": headers, "params": params})
         return SimpleNamespace(status_code=200, text="content")
 
     monkeypatch.setattr(rloopr_adapter_module.requests, "get", fake_get)
@@ -79,18 +98,22 @@ def test_rloopr_export_bedgraph(monkeypatch):
     )
 
     adapter = RLooprAdapter(user=_user())
-    content = adapter.export_bedgraph(id="analyse-id")
+    csv_content = adapter.export_csv(id="analyse-id", base_start=5, base_end=6)
+    bed_content = adapter.export_bedgraph(id="analyse-id", base_start=5, base_end=6)
 
-    assert content == "content"
-    assert captured["url"].endswith("/analyse/rloopr/analyse-id/rloopr.bedgraph")
+    assert csv_content == "content"
+    assert bed_content == "content"
+    assert calls[0]["url"].endswith("/analyse/rloopr/analyse-id/rloopr.csv")
+    assert calls[1]["url"].endswith("/analyse/rloopr/analyse-id/rloopr.bedgraph")
+    assert calls[0]["params"] == {"base_start": 5, "base_end": 6}
+    assert calls[1]["params"] == {"base_start": 5, "base_end": 6}
 
 
-def test_zdna_export_bedgraph(monkeypatch):
-    captured = {}
+def test_zdna_export_csv_and_bedgraph(monkeypatch):
+    calls = []
 
-    def fake_get(url, headers):
-        captured["url"] = url
-        captured["headers"] = headers
+    def fake_get(url, headers, params):
+        calls.append({"url": url, "headers": headers, "params": params})
         return SimpleNamespace(status_code=200, text="content")
 
     monkeypatch.setattr(zdna_adapter_module.requests, "get", fake_get)
@@ -101,7 +124,12 @@ def test_zdna_export_bedgraph(monkeypatch):
     )
 
     adapter = ZDnaAdapter(user=_user())
-    content = adapter.export_bedgraph(id="analyse-id")
+    csv_content = adapter.export_csv(id="analyse-id", base_start=7, base_end=8)
+    bed_content = adapter.export_bedgraph(id="analyse-id", base_start=7, base_end=8)
 
-    assert content == "content"
-    assert captured["url"].endswith("/analyse/zdna/analyse-id/zdna.bedgraph")
+    assert csv_content == "content"
+    assert bed_content == "content"
+    assert calls[0]["url"].endswith("/analyse/zdna/analyse-id/zdna.csv")
+    assert calls[1]["url"].endswith("/analyse/zdna/analyse-id/zdna.bedgraph")
+    assert calls[0]["params"] == {"base_start": 7, "base_end": 8}
+    assert calls[1]["params"] == {"base_start": 7, "base_end": 8}


### PR DESCRIPTION
### Motivation
- Add support for exporting analysis results in bedgraph format.
- Allow optional base-range filtering in exports via `base_start` and `base_end` query parameters.

### What Changed

#### Adapters
- Added `export_bedgraph(...)` methods for:
  - `G4Hunter`
  - `CpG`
  - `RLoopr`
  - `ZDna`
- Extended `export_csv(...)` and `export_bedgraph(...)` signatures with optional:
  - `base_start: int = 0`
  - `base_end: int = 0`
- Included `base_start` and `base_end` in request query params for both CSV and bedgraph endpoints.
- Preserved existing behavior such as `aggregate` in `G4Hunter`.

#### Ports
- Updated ports to expose the same optional parameters for both CSV and bedgraph export calls:
  - `g4hunter_port.py`
  - `cpg_port.py`
  - `rloopr_port.py`
  - `zdna_port.py`

#### Interfaces
- Added interface-level `export_bedgraph(...)` methods.
- Propagated `base_start` and `base_end` through interface export helpers to ports for both CSV and bedgraph exports.
- Ensured export flow remains consistent with existing file creation behavior.

#### Tests
- Added adapter-level tests in:
  - `tests/test_adapters/bedgraph_export_adapter_test.py`
- Tests verify:
  - correct CSV and bedgraph endpoint paths,
  - expected query params (`aggregate` where applicable, plus `base_start`/`base_end`),
  - expected returned text payload.

### Testing
- `pytest -q tests/test_adapters/bedgraph_export_adapter_test.py`